### PR TITLE
Rename `remove_event` to `delete_event`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -65,6 +65,8 @@
 * Remove Basecamp import methods
 * Remove undocumented `Mail#generate_custom_guid` method
 * `Community#update_event` require `type` and change to keyword arguments
+* Rename `remove_event` to `delete_event` according to official docs.
+  Keep old name as alias
 
 ## 0.6
 ### New features

--- a/lib/teamlab/modules/calendar.rb
+++ b/lib/teamlab/modules/calendar.rb
@@ -96,9 +96,11 @@ module Teamlab
       @request.delete(['events', event_id.to_s])
     end
 
-    def remove_event(event_id, options = {})
+    def delete_event(event_id, options = {})
       @request.delete(['events', event_id.to_s, 'custom'], options)
     end
+
+    alias remove_event delete_event
 
     def unsubscribe_from_event(event_id)
       @request.delete(['events', event_id.to_s, 'unsubscribe'])

--- a/spec/lib/calendar_spec.rb
+++ b/spec/lib/calendar_spec.rb
@@ -178,9 +178,9 @@ describe '[Calendar]' do
     end
   end
 
-  describe '#remove_event' do
+  describe '#delete_event' do
     it_should_behave_like 'an api request' do
-      let(:command) { :remove_event }
+      let(:command) { :delete_event }
       let(:args) { [DATA_COLLECTOR[:calendar_event_ids].pop] }
     end
   end


### PR DESCRIPTION
According to:
https://api.teamlab.info/portals/method/calendar/delete/api/2.0/calendar/events/%7beventid%7d/custom
Keep old name as alias to `delete_event`